### PR TITLE
feat: personalize public dotfiles configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,21 @@ git clone https://github.com/kunchenguid/dotfiles.git
 cd dotfiles
 ```
 
-Before you run it: open the config files and change the values listed in "Make it yours" below (username, home path, git identity, host label, and Intel vs Apple Silicon), and read the Homebrew cleanup warning.
+Before you run it: review "Make it yours" below.
+Change the host label or CPU architecture if needed, and read the Homebrew cleanup warning.
 `bootstrap.sh` applies the config to your machine, so do this first.
 
 ```sh
 ./bootstrap.sh
 ```
 
-`bootstrap.sh` does three things, in order:
+`bootstrap.sh` does four things, in order:
 
 1. Installs Determinate Nix, if it isn't already installed.
 2. Symlinks this repo to `~/.dotfiles`.
    This has to happen before the first build, because `home.nix` points at config files through `~/.dotfiles`.
-3. Runs the first `darwin-rebuild switch`.
+3. Checks the `user` configured in `flake.nix` against your actual macOS username, and offers to fix it for you if they differ.
+4. Runs the first `darwin-rebuild switch`.
    It fetches the `darwin-rebuild` tool from the nix-darwin 26.05 release branch, then applies this repo's locked flake config.
 
 After that, `darwin-rebuild` exists and you're on the normal workflow below.
@@ -74,13 +76,27 @@ No separate build-and-copy step.
 ## Make it yours
 
 This repo is mine.
-If you clone it, change these before you run `bootstrap.sh`:
+If you clone it, review these before you run `bootstrap.sh`:
 
-- **Username and home path** `kunchen` / `/Users/kunchen`, in four places: `flake.nix:26`, `configuration.nix:10-12`, `configuration.nix:30` (the `nix-homebrew.user` setting), and `home.nix:8-9`.
-- **Git identity**, in `home.nix:43-46` (`kunchenguid` / `kun@kunchenguid.com`).
-- **Host label** `"mac"`, in three places: `flake.nix:18` (the `darwinConfigurations."mac"` name), `rebuild.sh:5` (the `#mac` at the end of the flake reference), and `bootstrap.sh`'s first-switch command (also `#mac`).
+- **Username**: run `./bootstrap.sh` (it detects your macOS username and offers to set it) OR change the single `user = "kunchen"` line in `flake.nix`.
+  Everything else (`configuration.nix`, `home.nix`, home directory paths) is threaded from that one variable.
+- **Host label** `"mac"`, in three places: `flake.nix` (the `darwinConfigurations."mac"` name), `rebuild.sh:5` (the `#mac` at the end of the flake reference), and `bootstrap.sh`'s first-switch command (also `#mac`).
   All three have to match.
 - **CPU architecture**, `hostPlatform` in `configuration.nix` (see Prerequisites above).
+
+**Git identity:** this config deliberately does not set your git name or email.
+Git will stop your first commit and tell you to set them (`git config --global user.name "Your Name"` and `git config --global user.email you@example.com`).
+If you'd rather manage that declaratively, add this back to `home.nix` with your own identity:
+
+```nix
+programs.git = {
+  enable = true;
+  settings.user = {
+    name = "Your Name";
+    email = "you@example.com";
+  };
+};
+```
 
 **Homebrew cleanup warning:** `configuration.nix` sets `homebrew.onActivation.cleanup = "zap"`.
 That means every time you switch, Homebrew removes any package or cask on your machine that isn't listed in the `brews` and `casks` arrays in `configuration.nix`.
@@ -103,7 +119,7 @@ If you don't use it, just remove it from `brews` in your copy.
 - `flake.nix` - the entry point.
   Wires up nixpkgs, nix-darwin, home-manager, and nix-homebrew, and declares the `mac` machine.
 - `configuration.nix` - system-level config: macOS defaults, Homebrew.
-- `home.nix` - user-level config: shell, git, packages, and the symlinks described below.
+- `home.nix` - user-level config: shell, packages, prompt, and the symlinks described below.
 - `rebuild.sh` - re-applies the config after the first switch.
   Run this every time you make a change.
 - `home/` - the actual config files that get symlinked into place (Neovim, WezTerm, herdr, Claude settings, the shared `AGENTS.md`).

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,30 @@ echo "==> Step 2: symlink this repo to ~/.dotfiles"
 # has to exist before the first switch or the build will fail to find them.
 ln -sfn "$DIR" ~/.dotfiles
 
-echo "==> Step 3: first darwin-rebuild switch (pinned to nix-darwin-26.05)"
+echo "==> Step 3: personalize the configured username"
+# Do this before any sudo call: sudo resets $USER to root, so whoami has to
+# run as the real interactive user first.
+REAL_USER="$(whoami)"
+FLAKE_USER="$(sed -nE 's/^[[:space:]]*user = "([^"]+)";.*/\1/p' "$DIR/flake.nix" | head -n1)"
+if [ -z "$FLAKE_USER" ]; then
+  echo "    Could not find the single \"user = \" line in flake.nix."
+  echo "    Edit flake.nix yourself before continuing."
+  exit 1
+elif [ "$FLAKE_USER" != "$REAL_USER" ]; then
+  echo "    flake.nix is configured for user \"$FLAKE_USER\", but you are \"$REAL_USER\"."
+  read -r -p "    Rewrite flake.nix's \"user = \" line to \"$REAL_USER\"? [y/N] " REPLY
+  if [ "$REPLY" = "y" ] || [ "$REPLY" = "Y" ]; then
+    sed -i '' -E "s/^([[:space:]]*user = \")[^\"]+(\";.*)/\1${REAL_USER}\2/" "$DIR/flake.nix"
+    echo "    Updated. Review the change with: git diff flake.nix"
+  else
+    echo "    Skipped. Edit the single \"user = \" line in flake.nix yourself before continuing."
+    exit 1
+  fi
+else
+  echo "    flake.nix already matches \"$REAL_USER\", nothing to do."
+fi
+
+echo "==> Step 4: first darwin-rebuild switch (pinned to nix-darwin-26.05)"
 # darwin-rebuild doesn't exist yet on a fresh machine, so run it straight
 # from the flake this once. After this, rebuild.sh works normally.
 # This fetches the darwin-rebuild tool from the nix-darwin-26.05 release branch,

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ user, ... }:
 
 {
   # Determinate already manages the Nix daemon, so nix-darwin shouldn't.
@@ -7,9 +7,9 @@
   nixpkgs.config.allowUnfree = true;
   nixpkgs.hostPlatform = "aarch64-darwin"; # use x86_64-darwin for Intel CPU
 
-  system.primaryUser = "kunchen";
-  users.users.kunchen = {
-    home = "/Users/kunchen";
+  system.primaryUser = user;
+  users.users.${user} = {
+    home = "/Users/${user}";
   };
   system.stateVersion = 6;
   system.defaults = {
@@ -27,7 +27,7 @@
   };
   nix-homebrew = {
     enable = true;
-    user = "kunchen";
+    inherit user;
   };
   homebrew = {
     enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -14,18 +14,26 @@
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
   };
 
-  outputs = inputs@{ self, nix-darwin, nix-homebrew, home-manager, nixpkgs }: {
-    darwinConfigurations."mac" = nix-darwin.lib.darwinSystem {
-      modules = [ 
-        ./configuration.nix 
-        nix-homebrew.darwinModules.nix-homebrew
-        home-manager.darwinModules.home-manager
-        {
-          home-manager.useGlobalPkgs = true;
-          home-manager.useUserPackages = true;
-          home-manager.users.kunchen = import ./home.nix;
-        }
-      ];
+  outputs = inputs@{ self, nix-darwin, nix-homebrew, home-manager, nixpkgs }:
+    let
+      # The one username line to change if this isn't your machine.
+      # bootstrap.sh offers to rewrite this for you if your macOS username differs.
+      user = "kunchen";
+    in
+    {
+      darwinConfigurations."mac" = nix-darwin.lib.darwinSystem {
+        specialArgs = { inherit user; };
+        modules = [
+          ./configuration.nix
+          nix-homebrew.darwinModules.nix-homebrew
+          home-manager.darwinModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.extraSpecialArgs = { inherit user; };
+            home-manager.users.${user} = import ./home.nix;
+          }
+        ];
+      };
     };
-  };
 }

--- a/home.nix
+++ b/home.nix
@@ -1,12 +1,12 @@
-{ config, pkgs, ... }:
+{ config, pkgs, user, ... }:
 
 let
   dotfiles = "${config.home.homeDirectory}/.dotfiles";
 in
 
 {
-  home.username = "kunchen";
-  home.homeDirectory = "/Users/kunchen";
+  home.username = user;
+  home.homeDirectory = "/Users/${user}";
   home.stateVersion = "24.11";
   home.packages = with pkgs; [
     # cli i use constantly
@@ -38,11 +38,6 @@ in
       cc = "claude --dangerously-skip-permissions";
       co = "codex --full-auto";
     };
-  };
-
-  programs.git.settings.user = {
-    name = "kunchenguid";
-    email = "kun@kunchenguid.com";
   };
 
   programs.starship = {


### PR DESCRIPTION
## Intent

Two captain-approved personalization changes to the public dotfiles repo, explicitly authorized to diverge from what the accompanying video shows on camera. (1) Remove the hardcoded git identity block (programs.git.settings.user with name=kunchenguid/email=kun@kunchenguid.com) from home.nix entirely, with no placeholder - the deliberate intent is that git itself prompts new users to set their identity on first commit, which is the intended teaching behavior. README.md gets an honest 'Git identity' note explaining this and showing the optional block a user can add back with their own identity. (2) Consolidate the previously hardcoded 'kunchen' username (repeated in ~6 places across flake.nix, configuration.nix, home.nix) into a single 'user' binding defined in a let inside flake.nix's outputs, threaded via specialArgs (to configuration.nix) and home-manager.extraSpecialArgs (to home.nix), with home-manager.users.${user} replacing home-manager.users.kunchen. configuration.nix and home.nix take user as a module arg and use it for system.primaryUser, users.users.${user}, its home path, nix-homebrew.user, home.username, and home.homeDirectory. The host label "mac" is deliberately left untouched (out of scope). bootstrap.sh gets a new interactive personalization step inserted BEFORE any sudo call (since sudo resets $USER to root) and before the first darwin-rebuild switch: it compares whoami against the user configured in flake.nix, and if they differ, offers a y/N prompt to rewrite just that one 'user = "..."' line in flake.nix via macOS/BSD sed -i '', telling the user to review with git diff. README's 'Make it yours' section is simplified to point at bootstrap.sh's detection or the single user= line, and the old separate git-identity bullet there was removed since it now has its own note. The captain explicitly declined bringing over any script-test framework, so no tests/ directory or test tooling should be added - validation is via nix flake check, a non-activating nix build .#darwinConfigurations.mac.system closure build, nix eval checks confirming user threading resolves correctly and that no git identity gets written, and shellcheck on bootstrap.sh, all of which I already ran manually and passed. The hard safety rule is that this must never activate the system - no darwin-rebuild switch, no home-manager switch, no sudo nix run ... switch, and bootstrap.sh must never be run end-to-end; only non-activating validation is allowed, and --impure must never be used anywhere. This repo also bans committing .no-mistakes/evidence to the public repo (documented in AGENTS.md and gitignored), so any evidence the pipeline stages into this branch must be stripped in a clean rebuild onto origin/main before merge.

## What Changed

- Consolidated the local username into a single `user` binding in `flake.nix` and threaded it through the Darwin, Home Manager, and nix-homebrew configuration.
- Removed the hardcoded Git identity from Home Manager so new users configure their own identity when Git requires it.
- Added pre-activation bootstrap personalization for the configured username and updated README guidance for personalization and optional Git identity setup.

## Risk Assessment

✅ Low: The change is narrowly scoped to username threading, bootstrap guardrails, and README guidance, with no material correctness or security risks found in the reviewed diff.

## Testing

Inspected the committed diff, ran `nix flake check`, built `.#darwinConfigurations.mac.system` with `--no-link`, evaluated the resolved darwin/home-manager config for the default user, and used a throwaway evidence-directory fixture to rewrite only the `user = ...` line and re-evaluate the personalized config. The evaluated config threads the user through the expected fields and shows no git user settings or generated git config; no activation, sudo, switch, `--impure`, linter, formatter, or static-analysis command was run, and no worktree artifacts were left behind.

<details>
<summary>Evidence: nix flake check transcript</summary>

<code>evaluating &#39;darwinConfigurations&#39;...&#10;evaluating &#39;darwinConfigurations&#39;...&#10;evaluating &#39;darwinConfigurations.mac&#39;...&#10;✅ darwinConfigurations.mac (build skipped)</code>

```text
evaluating 'darwinConfigurations'...
evaluating 'darwinConfigurations'...
evaluating 'darwinConfigurations.mac'...
✅ darwinConfigurations.mac (build skipped)
```
</details>
<details>
<summary>Evidence: non-activating darwin system build</summary>

<code>warning: Using &#39;builtins.derivation&#39; to create a derivation named &#39;options.json&#39; that references the store path &#39;/nix/store/3ggqbw7xv4cz69avafv82bb7k2m93hrc-source&#39; without a proper context. The resulting derivation will not have a correct store reference, so this is unreliable and may stop working in the future.&#10;/nix/store/6bmjg5flhg2h78g82vl35sxrdfxql702-darwin-system-26.05.adda04f</code>

```text
warning: Using 'builtins.derivation' to create a derivation named 'options.json' that references the store path '/nix/store/3ggqbw7xv4cz69avafv82bb7k2m93hrc-source' without a proper context. The resulting derivation will not have a correct store reference, so this is unreliable and may stop working in the future.
/nix/store/6bmjg5flhg2h78g82vl35sxrdfxql702-darwin-system-26.05.adda04f
```
</details>
<details>
<summary>Evidence: current resolved config</summary>

`{"darwinUserHome":"/Users/kunchen","gitConfigFilePresent":false,"gitProgramEnabled":false,"gitUserSettingsPresent":false,"hmHomeDirectory":"/Users/kunchen","hmUserName":"kunchen","homeManagerUsers":["kunchen"],"nixHomebrewUser":"kunchen","primaryUser":"kunchen"}`

```text
{"darwinUserHome":"/Users/kunchen","gitConfigFilePresent":false,"gitProgramEnabled":false,"gitUserSettingsPresent":false,"hmHomeDirectory":"/Users/kunchen","hmUserName":"kunchen","homeManagerUsers":["kunchen"],"nixHomebrewUser":"kunchen","primaryUser":"kunchen"}
```
</details>
<details>
<summary>Evidence: bootstrap personalization dry run</summary>

<code>Fixture flake user line before rewrite:&#10;user = &#34;kunchen&#34;;&#10;Fixture flake user line after rewriting only that line:&#10;user = &#34;no_mistakes_user&#34;;&#10;Resolved darwin/home-manager config from personalized fixture:&#10;{&#34;darwinUserHome&#34;:&#34;/Users/no_mistakes_user&#34;,&#34;gitConfigFilePresent&#34;:false,&#34;gitProgramEnabled&#34;:false,&#34;gitUserSettingsPresent&#34;:false,&#34;hmHomeDirectory&#34;:&#34;/Users/no_mistakes_user&#34;,&#34;hmUserName&#34;:&#34;no_mistakes_user&#34;,&#34;homeManagerUsers&#34;:[&#34;no_mistakes_user&#34;],&#34;nixHomebrewUser&#34;:&#34;no_mistakes_user&#34;,&#34;primaryUser&#34;:&#34;no_mistakes_user&#34;}</code>

```text
Fixture flake user line before rewrite:
user = "kunchen";
Fixture flake user line after rewriting only that line:
user = "no_mistakes_user";
Resolved darwin/home-manager config from personalized fixture:
{"darwinUserHome":"/Users/no_mistakes_user","gitConfigFilePresent":false,"gitProgramEnabled":false,"gitUserSettingsPresent":false,"hmHomeDirectory":"/Users/no_mistakes_user","hmUserName":"no_mistakes_user","homeManagerUsers":["no_mistakes_user"],"nixHomebrewUser":"no_mistakes_user","primaryUser":"no_mistakes_user"}
```
</details>
<details>
<summary>Evidence: personalized fixture resolved config</summary>

`{"darwinUserHome":"/Users/no_mistakes_user","gitConfigFilePresent":false,"gitProgramEnabled":false,"gitUserSettingsPresent":false,"hmHomeDirectory":"/Users/no_mistakes_user","hmUserName":"no_mistakes_user","homeManagerUsers":["no_mistakes_user"],"nixHomebrewUser":"no_mistakes_user","primaryUser":"no_mistakes_user"}`

```text
{"darwinUserHome":"/Users/no_mistakes_user","gitConfigFilePresent":false,"gitProgramEnabled":false,"gitUserSettingsPresent":false,"hmHomeDirectory":"/Users/no_mistakes_user","hmUserName":"no_mistakes_user","homeManagerUsers":["no_mistakes_user"],"nixHomebrewUser":"no_mistakes_user","primaryUser":"no_mistakes_user"}
```
</details>
<details>
<summary>Evidence: README personalization and git identity excerpt</summary>

```text

This repo is mine.
If you clone it, change these before you run `bootstrap.sh`:

- **Username**: run `./bootstrap.sh` (it detects your macOS username and offers to set it) OR change the single `user = "kunchen"` line in `flake.nix`.
  Everything else (`configuration.nix`, `home.nix`, home directory paths) is threaded from that one variable.
- **Host label** `"mac"`, in three places: `flake.nix` (the `darwinConfigurations."mac"` name), `rebuild.sh:5` (the `#mac` at the end of the flake reference), and `bootstrap.sh`'s first-switch command (also `#mac`).
  All three have to match.
- **CPU architecture**, `hostPlatform` in `configuration.nix` (see Prerequisites above).

**Git identity:** this config deliberately does not set your git name or email.
Git itself will ask you for them the first time you commit (`git config --global user.name "Your Name"` and `git config --global user.email you@example.com`).
If you'd rather manage that declaratively, add this back to `home.nix` with your own identity:

`` `nix
programs.git = {
  enable = true;
  settings.user = {
    name = "Your Name";
    email = "you@example.com";
  };
};
`` `

**Homebrew cleanup warning:** `configuration.nix` sets `homebrew.onActivation.cleanup = "zap"`.
That means every time you switch, Homebrew removes any package or cask on your machine that isn't listed in the `brews` and `casks` arrays in `configuration.nix`.
If you already have Homebrew stuff installed that isn't in that list, the first switch will uninstall it.
Read through `brews` and `casks` before you run `bootstrap.sh` or `rebuild.sh` for the first time, and add anything you want to keep.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bootstrap.sh:35` - When the configured flake user differs and the user answers the default `N`, the script only prints that they should edit `flake.nix` before continuing, then falls through to Step 4 and runs `darwin-rebuild switch` with the wrong `system.primaryUser`, Home Manager user, and nix-homebrew user. Exit non-zero after this branch, or otherwise stop before activation until the mismatch is fixed.
- ⚠️ `README.md:91` - This optional Home Manager snippet is incomplete in this repo because `programs.git.settings` is only written when `programs.git.enable = true`, and `home.nix` does not enable the Git module. Users who paste this block will still not get a declarative git identity; show the full `programs.git = { enable = true; settings.user = ...; };` form or the equivalent enabled config.

🔧 Fix: Block unsafe bootstrap and fix Git docs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 1d657e15cc66d2a8a3f42640263a996296ea0a09..678cee1b6574c1f546cc517fe284b607df31916e` and `git diff --name-only 1d657e15cc66d2a8a3f42640263a996296ea0a09..678cee1b6574c1f546cc517fe284b607df31916e`</code>
- `rg -n "programs\.git|settings\.user|user =|home-manager\.users|system\.primaryUser|nix-homebrew\.user|home\.username|home\.homeDirectory|kunchen|kunchenguid|kun@kunchenguid" flake.nix configuration.nix home.nix README.md bootstrap.sh`
- `nix flake check`
- `nix build .#darwinConfigurations.mac.system --no-link --print-out-paths`
- `nix eval --no-eval-cache --json .#darwinConfigurations.mac.config --apply '<checked resolved username, home paths, nix-homebrew user, home-manager user, and git identity absence fields>'`
- <code>Dry-run personalization fixture: `git archive HEAD | tar -x -C &#34;$F&#34;`, `sed -i &#34;&#34; -E &#39;s/^([[:space:]]*user = &#34;)[^&#34;]+(&#34;;.*)/\\1no_mistakes_user\\2/&#39; &#34;$F/flake.nix&#34;`, then `nix eval --no-eval-cache --json &#34;$F#darwinConfigurations.mac.config&#34; --apply &#39;&lt;checked same fields for no_mistakes_user&gt;&#39;`</code>
- `sed -n '76,104p' README.md > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KWW632BV5HQ8K6R6X9G83CVQ/readme-personalization-git-identity-excerpt.md`
- <code>`git status --short --branch` and `find . -maxdepth 2 -name result -o -name &#39;result-*&#39;`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
