### PR TITLE
Customize dotfiles for mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you find a bug, please open a GitHub Issue using the bug report template.
 Running the switch builds:
 
 - System settings (dark mode, key repeat, dock, Finder, trackpad)
-- Homebrew apps (casks and CLI tools)
+- Homebrew apps and CLI tools (AI agents, remote access, terminal, editor, local dev)
 - Nix user packages (ripgrep, fd, fzf, jq, lazygit, Neovim, Hack Nerd Font)
 - Shell (zsh, aliases, starship prompt)
 - Editor (Neovim config)
@@ -108,6 +108,8 @@ programs.git = {
 That means every time you switch, Homebrew removes any package or cask on your machine that isn't listed in the `brews` and `casks` arrays in `configuration.nix`.
 If you already have Homebrew stuff installed that isn't in that list, the first switch will uninstall it.
 Read through `brews` and `casks` before you run `bootstrap.sh` or `rebuild.sh` for the first time, and add anything you want to keep.
+This profile currently preserves the high-confidence tools found in active use on mini's machine: Cursor, Claude/Claude Code, Codex, opencode, Antigravity, Tailscale, NoMachine, OrbStack, Obsidian, RustDesk, 1Password, Android platform tools, GitHub CLI, just, uv, tmux, Node, Coreutils, and ffmpeg-full.
+Anything else installed manually or through Homebrew should be treated as at risk until you either add it here or intentionally let `zap` remove it.
 
 **About `herdr`:** it's in the `brews` list.
 It's a real public Homebrew formula (`brew info herdr` finds it in homebrew-core, no tap needed), so it will install fine.

--- a/configuration.nix
+++ b/configuration.nix
@@ -31,15 +31,38 @@
   };
   homebrew = {
     enable = true;
-    onActivation.cleanup = "zap";  # remove anything not listed here
+    # High impact: `zap` removes Homebrew items not listed below on switch.
+    # Review brews/casks before bootstrap or rebuild on an existing machine.
+    onActivation.cleanup = "zap";
     onActivation.autoUpdate = true;
     onActivation.extraFlags = [ "--force" ];
     brews = [
+      "coreutils"
+      "ffmpeg-full"
+      "gh"
       "herdr"
+      "just"
+      "node"
+      "opencode"
+      "tailscale"
+      "tmux"
+      "uv"
     ];
     casks = [
-      "wezterm"
+      "1password"
+      "1password-cli"
+      "android-platform-tools"
+      "antigravity"
+      "claude"
       "claude-code"
+      "codex"
+      "cursor"
+      "nomachine"
+      "obsidian"
+      "orbstack"
+      "rustdesk"
+      "tailscale-app"
+      "wezterm"
     ];
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     let
       # The one username line to change if this isn't your machine.
       # bootstrap.sh offers to rewrite this for you if your macOS username differs.
-      user = "kunchen";
+      user = "mini";
     in
     {
       darwinConfigurations."mac" = nix-darwin.lib.darwinSystem {


### PR DESCRIPTION
## Summary

- Set the nix-darwin user to `mini`.
- Preserve currently used apps and agent tooling declaratively before `zap` cleanup runs.
- Document the higher-impact Homebrew cleanup review expectations.

## Validation

- `git diff --check`: passed
- Brew formula/cask token resolution: passed
- Nix checks were not run because `nix` was not available in this shell.
