### PR TITLE
fix(wezterm): prevent Herdr from swallowing Escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Read through `brews` and `casks` before you run `bootstrap.sh` or `rebuild.sh` f
 
 **About `herdr`:** it's in the `brews` list.
 It's a real public Homebrew formula (`brew info herdr` finds it in homebrew-core, no tap needed), so it will install fine.
+The tracked WezTerm config enables the kitty keyboard protocol so Escape is sent as an atomic key event instead of being swallowed by Herdr when a mouse event follows it closely.
 If you don't use it, just remove it from `brews` in your copy.
 
 **Heads-up:**

--- a/home/.config/wezterm/wezterm.lua
+++ b/home/.config/wezterm/wezterm.lua
@@ -10,4 +10,8 @@ config.macos_window_background_blur = 50
 config.hide_tab_bar_if_only_one_tab = true
 config.window_decorations = "RESIZE"
 
+-- Emit Esc as an atomic key event (\x1b[27u) so Herdr can't fold a lone
+-- Escape into a tailgating mouse event and swallow it in editors like Neovim.
+config.enable_kitty_keyboard = true
+
 return config


### PR DESCRIPTION
## Intent

Fix the confirmed Herdr Escape-swallow bug for viewers who follow this public dotfiles setup. Inside Herdr, a lone Escape is held ~150ms and coalesces with a tailgating SGR mouse event which Herdr drops, swallowing Escape in editors like Neovim. The clean, minimal fix is to enable the kitty keyboard protocol in this repo's tracked WezTerm config so WezTerm emits Escape as an atomic key event (\x1b[27u), and Herdr never enters the hold/fold path.

Scope: add exactly one config option, config.enable_kitty_keyboard = true (matching WezTerm's Lua API), to home/.config/wezterm/wezterm.lua, plus one concise comment explaining it makes Esc atomic so Herdr does not swallow it. Purely additive; nothing else changed. Placed at the end of the config block before 'return config', matching the file's existing 'config.xxx = value' style.

This is a PUBLIC on-camera teaching repo. Intentional constraints a reviewer should not flag: the change is deliberately minimal (single option + comment); no root AGENTS.md/CLAUDE.md agent-scaffolding should be added to this repo (project knowledge for viewers lives in the README); .no-mistakes/ stays untracked and must not be committed.

## What Changed

- Enable WezTerm's kitty keyboard protocol so Escape is emitted atomically and is not swallowed by Herdr when followed closely by a mouse event.
- Document the Herdr-safe Escape behavior in the README.

## Risk Assessment

✅ Low: The change is narrowly scoped, uses the documented WezTerm option correctly, and introduces no material correctness, compatibility, security, or maintainability concerns.

## Testing

Inspected the complete baseline-to-target diff, loaded the tracked configuration with installed WezTerm 20240203, and captured evidence that the intended option is accepted. The change passed; direct Escape-byte capture was not feasible without an interactive Herdr terminal session.

<details>
<summary>Evidence: WezTerm configuration verification transcript</summary>

<code>wezterm 20240203-110809-5046fc22&#10;config file: home/.config/wezterm/wezterm.lua&#10;resolved option source: 15:config.enable_kitty_keyboard = true&#10;config load: wezterm show-keys completed successfully&#10;changed paths and line counts:&#10;4 0 home/.config/wezterm/wezterm.lua</code>

```text
wezterm 20240203-110809-5046fc22
config file: home/.config/wezterm/wezterm.lua
resolved option source: 15:config.enable_kitty_keyboard = true
config load: wezterm show-keys completed successfully
changed paths and line counts:
4	0	home/.config/wezterm/wezterm.lua
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --no-ext-diff ad6fe1d9f43dfbf96d577b619fb8d5d99ce3174b b2115553b829bb3023e1d256f222798cff93f30f -- home/.config/wezterm/wezterm.lua`
- `wezterm --config-file home/.config/wezterm/wezterm.lua show-keys`
- `rg -n '^config\.enable_kitty_keyboard = true$' home/.config/wezterm/wezterm.lua`
- `git diff --numstat ad6fe1d9f43dfbf96d577b619fb8d5d99ce3174b b2115553b829bb3023e1d256f222798cff93f30f`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
