### PR TITLE
fix: restore Escape input in WezTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Read through `brews` and `casks` before you run `bootstrap.sh` or `rebuild.sh` f
 
 **About `herdr`:** it's in the `brews` list.
 It's a real public Homebrew formula (`brew info herdr` finds it in homebrew-core, no tap needed), so it will install fine.
-The tracked WezTerm config enables the kitty keyboard protocol so Escape is sent as an atomic key event instead of being swallowed by Herdr when a mouse event follows it closely.
 If you don't use it, just remove it from `brews` in your copy.
 
 **Heads-up:**

--- a/home/.config/wezterm/wezterm.lua
+++ b/home/.config/wezterm/wezterm.lua
@@ -10,8 +10,4 @@ config.macos_window_background_blur = 50
 config.hide_tab_bar_if_only_one_tab = true
 config.window_decorations = "RESIZE"
 
--- Emit Esc as an atomic key event (\x1b[27u) so Herdr can't fold a lone
--- Escape into a tailgating mouse event and swallow it in editors like Neovim.
-config.enable_kitty_keyboard = true
-
 return config


### PR DESCRIPTION
## Intent

URGENT ROLLBACK in this public teaching repo. PR #15 added config.enable_kitty_keyboard = true to home/.config/wezterm/wezterm.lua (plus a two-line comment above it) and a README explainer line about the kitty keyboard protocol. That option caused a total-loss regression: physical Escape never registers in Neovim under Herdr after a rebuild. The fix removes BOTH additions from PR #15 and nothing else: (1) the two comment lines and the config.enable_kitty_keyboard option in wezterm.lua, cleaning up the orphaned blank line so there is a single blank line before 'return config'; (2) the single README explainer sentence on the 'About herdr' paragraph. This is a pure revert with footprint of exactly those two removals - no other behavior, docs, or files change. Because it is a public teaching repo, the goal is that a viewer who copies this config simply no longer has the broken option.

## What Changed

- Remove the WezTerm setting that explicitly enables the kitty keyboard protocol, restoring physical Escape input in Neovim under Herdr.
- Remove the corresponding kitty keyboard protocol explanation from the README.

## Risk Assessment

✅ Low: The change is a tightly scoped rollback that exactly restores the repository tree to the state before PR #15, with no unrelated changes or residual documentation inconsistencies.

## Testing

Verified the five-line, two-file rollback footprint, loaded the copied configuration successfully with WezTerm, confirmed all broken-option text is absent, and proved the target tree exactly matches the pre-PR #15 tree; the transcript captures the end-user configuration and documentation surfaces, and no screenshot was applicable because this is a configuration rollback with no rendered UI change.

<details>
<summary>Evidence: Rollback end-to-end transcript</summary>

```text
End-user WezTerm config load
$ wezterm --config-file home/.config/wezterm/wezterm.lua show-keys --key-table default
exit_status=0
loaded_key_assignments=274

Rollback behavior checks
$ rg -n "enable_kitty_keyboard|kitty keyboard protocol|atomic key event|tailgating mouse" README.md home
removed_setting_and_explainer=absent

Exact revert check
$ git diff --quiet 95cf01b^ b1a7394
target_tree_matches_pre_PR15_tree=ad6fe1d9f43dfbf96d577b619fb8d5d99ce3174b

Final config tail (visible copy surface)
config.font_size = 15.0
config.window_background_opacity = 0.8
config.macos_window_background_blur = 50
config.hide_tab_bar_if_only_one_tab = true
config.window_decorations = "RESIZE"

return config

README herdr paragraph (visible teaching surface)
**About `herdr`:** it's in the `brews` list.
It's a real public Homebrew formula (`brew info herdr` finds it in homebrew-core, no tap needed), so it will install fine.
If you don't use it, just remove it from `brews` in your copy.

**Heads-up:**

- `home/AGENTS.md` is my personal agent policy, and `home.nix` installs it for Claude, Codex, and opencode.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --no-ext-diff --unified=20 95cf01b042f23513cc86afbaa64c7d306b00467f..b1a739474cec41b11d20a719cc360d6afc76cef8`
- `git diff --check 95cf01b042f23513cc86afbaa64c7d306b00467f..b1a739474cec41b11d20a719cc360d6afc76cef8`
- `wezterm --config-file home/.config/wezterm/wezterm.lua show-keys --key-table default`
- `rg -n "enable_kitty_keyboard|kitty keyboard protocol|atomic key event|tailgating mouse" README.md home`
- `git diff --quiet 95cf01b^ b1a7394`
- <code>Manually inspected the final WezTerm config tail and README `herdr` paragraph in the evidence transcript.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
