### PR TITLE
fix: prevent Herdr from swallowing Escape

### DIFF
--- a/home/.config/herdr/config.toml
+++ b/home/.config/herdr/config.toml
@@ -12,3 +12,8 @@ workspace_picker = "prefix+w"
 goto             = "prefix+g"
 copy_mode  = "prefix+y"  # herdr's copy-mode entry key; copy-mode's own internal keys (v/space select, y/Enter copy, q/Esc cancel) aren't configurable
 
+[ui]
+# Disable Herdr's host mouse capture so a trackpad event can't tailgate a held
+# Escape and get it swallowed in the pane (e.g. Neovim stuck in insert mode).
+# Only effective together with the pane keeping mouse off (see nvim mouse below).
+mouse_capture = false

--- a/home/.config/nvim/lua/vim_config.lua
+++ b/home/.config/nvim/lua/vim_config.lua
@@ -9,4 +9,5 @@ o.smartcase = true             -- case-sensitive only if i type a capital
 o.clipboard = 'unnamedplus'    -- share the system clipboard
 o.scrolloff = 16               -- keep cursor away from the screen edge
 o.undofile = true              -- persistent undo across sessions
+o.mouse = ''                   -- no mouse in nvim; also lets Herdr keep host mouse capture off so Escape isn't swallowed
 


### PR DESCRIPTION
## Intent

Ship both required halves of the verified Herdr Escape-swallow mitigation to this public teaching dotfiles repo so it is actually effective for viewers who follow this setup. Herdr computes should_capture_host_mouse = ui.mouse_capture || pane_requests_mouse, so the mitigation only works when host mouse capture is off on BOTH sides: (1) Herdr's own config (home/.config/herdr/config.toml) - add a new [ui] table with mouse_capture = false; and (2) the pane side, Neovim (home/.config/nvim/lua/vim_config.lua) which currently defaults to mouse-on - add o.mouse = '' in the existing 'local o = vim.opt' / o.<opt> style. Deliberate decisions: exactly these two additions, nothing else; each carries a short explanatory comment matching each file's existing comment style; no other files touched; do not rewrite historical recorded video-source/snippet content (none exists in this repo); no AGENTS.md/CLAUDE.md agent files added; .no-mistakes/ stays untracked. A Herdr-only change would be a no-op here because Neovim defaults to mouse-on, which is exactly why both halves are required.

## What Changed

- Disable Herdr host mouse capture to prevent trackpad events from causing Escape to be swallowed.
- Disable Neovim mouse handling so Herdr can consistently keep host mouse capture off.

## Risk Assessment

✅ Low: The change is narrowly scoped, uses valid configuration patterns, and consistently disables both Herdr host capture and Neovim pane mouse reporting without introducing a material regression.

## Testing

After an initial overlong-socket-path setup failure was corrected with isolated worktree-local sockets, Herdr 0.7.3 accepted and live-reloaded the shipped configuration without diagnostics, Neovim 0.12.0 evaluated the shipped configuration with mouse disabled, deployment wiring for both files was confirmed, runtime evidence was captured, and the worktree was left clean.

<details>
<summary>Evidence: Escape mitigation runtime evidence</summary>

<code>Herdr reload: status `applied`, diagnostics `[]`.&#10;Neovim runtime: `vim.opt.mouse = {}`.&#10;Combined state: Herdr host capture disabled and Neovim mouse disabled.</code>

```text
Herdr live config reload (Herdr 0.7.3):
{"id":"cli:server:reload-config","result":{"diagnostics":[],"status":"applied","type":"config_reload"}}

Neovim runtime option (Neovim 0.12.0, repository vim_config.lua sourced):
vim.opt.mouse = {}

Combined mitigation state:
Herdr ui.mouse_capture = false; Neovim mouse = empty
```
</details>
<details>
<summary>Evidence: Herdr server runtime log</summary>

`Herdr startup, reload, and clean shutdown log.`

```text
2026-07-11T18:49:09.451835Z  INFO herdr::platform::macos: raised server file descriptor soft limit previous=256 target=8192
2026-07-11T18:49:28.502645Z  INFO herdr::platform::macos: raised server file descriptor soft limit previous=256 target=8192
2026-07-11T18:49:28.502983Z  INFO herdr::api::server: api server listening path=.herdr-test.sock
2026-07-11T18:49:28.503253Z  INFO herdr::app: using pane scrollback configuration pane_scrollback_limit_bytes=10000000
2026-07-11T18:49:28.512603Z  INFO herdr::logging: checking for updates event="update.check.start" subsystem="update" outcome="started"
2026-07-11T18:49:28.512716Z  INFO herdr::server::headless: client protocol socket listening path=.herdr-test-client.sock
2026-07-11T18:49:28.512735Z  INFO herdr::server::headless: herdr server started api_socket=.herdr-test.sock client_socket=.herdr-test-client.sock
2026-07-11T18:49:28.512760Z  INFO herdr::logging: herdr starting event="app.startup" subsystem="server" outcome="started" pid=6216
2026-07-11T18:49:28.807000Z  WARN herdr::detect::manifest_update: skipping unknown remote manifest agent agent="maki"
2026-07-11T18:49:36.200176Z  INFO herdr::logging: api request received event="api.request.start" subsystem="api" outcome="started" request_id="cli:server:reload-config" method="server.reload_config" changes_ui=true
2026-07-11T18:49:36.200406Z  INFO herdr::logging: api request completed event="api.request.complete" subsystem="api" outcome="ok" request_id="cli:server:reload-config" method="server.reload_config"
2026-07-11T18:49:39.381855Z  INFO herdr::server::headless: server shutdown initiated
2026-07-11T18:49:39.482472Z  INFO herdr::server::headless: completing server shutdown
2026-07-11T18:49:39.482828Z  INFO herdr::logging: session cleared event="persist.clear" subsystem="persist" outcome="ok" path=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KX984321VX7RYR01C3NDMVMK/.config/herdr/session.json
2026-07-11T18:49:39.482866Z  INFO herdr::server::headless: headless server exiting
2026-07-11T18:49:39.483691Z  INFO herdr::logging: herdr exiting event="app.shutdown" subsystem="server" outcome="completed" pid=6216
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat f068d43326867f8b531526d9b5fffbf6a02072c0..a0f8972b367f4edbbfda5f8fb35dadc1d8e2831b` and the corresponding full diff to confirm only the intended two files changed</code>
- <code>Started Herdr 0.7.3 with `HERDR_CONFIG_PATH=$PWD/home/.config/herdr/config.toml` and isolated worktree-local sockets</code>
- <code>Ran `herdr server reload-config` against the isolated server and observed `status: applied` with no diagnostics</code>
- <code>Ran `nvim --clean --headless -u NONE` with the repository `vim_config.lua` sourced and observed `vim.opt.mouse = {}`</code>
- <code>Verified `home.nix` deploys both repository configuration directories through Home Manager out-of-store symlinks</code>
- `Stopped the isolated Herdr server, removed its worktree-local sockets, and verified the working tree remained clean`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
