### PR TITLE
fix: improve Herdr usability with mouse capture disabled

### DIFF
--- a/home/.config/herdr/config.toml
+++ b/home/.config/herdr/config.toml
@@ -17,3 +17,7 @@ copy_mode  = "prefix+y"  # herdr's copy-mode entry key; copy-mode's own internal
 # Escape and get it swallowed in the pane (e.g. Neovim stuck in insert mode).
 # Only effective together with the pane keeping mouse off (see nvim mouse below).
 mouse_capture = false
+# Agents panel order: "spaces" (grouped by space, the default) vs "priority".
+# Set explicitly because with mouse_capture=false the header click-toggle is
+# unreachable, so the sort is fixed by this value.
+agent_panel_sort = "spaces"

--- a/home/.config/wezterm/wezterm.lua
+++ b/home/.config/wezterm/wezterm.lua
@@ -10,4 +10,11 @@ config.macos_window_background_blur = 50
 config.hide_tab_bar_if_only_one_tab = true
 config.window_decorations = "RESIZE"
 
+-- With Herdr mouse_capture=false, the Herdr client is a full-screen alt-screen app
+-- enabling no mouse reporting, so WezTerm would otherwise synthesize Up/Down arrow
+-- keys for wheel scroll (default speed 3) and a pane REPL reads them as history
+-- navigation. Set to 0 so wheel input in alternate-screen apps is never turned into
+-- arrow keys. Scroll pane scrollback with PageUp/PageDown or copy-mode (prefix+y).
+config.alternate_buffer_wheel_scroll_speed = 0
+
 return config


### PR DESCRIPTION
## Intent

Ship two approved, additive-only Herdr/WezTerm config changes to this PUBLIC dotfiles repo for parity with the already-shipped mouse_capture=false mitigation (PR #17). Both changes are direct consequences of that mitigation, so anyone following this setup hits the same issues.

1) home/.config/herdr/config.toml: inside the SAME existing [ui] table that holds mouse_capture=false, add agent_panel_sort = "spaces" with an explanatory comment. Rationale: with mouse_capture=false the Herdr header click-toggle for the agents-panel sort is unreachable, so the sort must be pinned explicitly to its default ("spaces", grouped by space; the alternative is "priority").

2) home/.config/wezterm/wezterm.lua: before the final 'return config', add config.alternate_buffer_wheel_scroll_speed = 0 with an explanatory comment, matching the file's existing style. Rationale: with mouse_capture=false the Herdr client is a full-screen alt-screen app enabling no mouse reporting, so WezTerm would otherwise synthesize Up/Down arrow keys for wheel scroll (default speed 3) and a pane REPL reads them as history navigation; 0 disables that synthesis. Scrollback still works via PageUp/PageDown or copy-mode (prefix+y).

Deliberate constraints (do NOT flag as mistakes): mouse_capture stays false and is intentionally unchanged; no [keys] binding or any other line is touched; both edits are purely additive (net +11 lines, comments included) and the comments are reader-facing on purpose since this is a public repo. No AGENTS.md/CLAUDE.md agent files are added. Footprint is exactly these two additions.

## What Changed

- Pin Herdr’s agents panel sort to `spaces` because its header toggle is unavailable when mouse capture is disabled.
- Disable WezTerm’s alternate-buffer wheel-to-arrow synthesis to prevent wheel input from navigating REPL history, while retaining PageUp/PageDown and copy-mode scrolling.

## Risk Assessment

✅ Low: The change is narrowly scoped, purely additive, matches the authoritative intent exactly, and introduces no substantiated correctness or compatibility risks.

## Testing

Verified the exact two-file, additive-only +11-line footprint, launched Herdr with the changed configuration and observed `spaces` on the real agents-panel surface, loaded the WezTerm configuration successfully through WezTerm itself, captured a reviewer-readable evidence transcript, and confirmed the worktree remained clean.

<details>
<summary>Evidence: End-to-end configuration evidence</summary>

`Herdr rendered the agents-panel header as "spaces"; WezTerm loaded the changed configuration successfully. The transcript also records the exact two-file, +11-line additive footprint.`

```text
End-to-end configuration evidence

Herdr runtime launch:
  Command: HOME=.test-home HERDR_CONFIG_PATH=<worktree>/home/.config/herdr/config.toml herdr --no-session
  Result: launched successfully in a PTY; the real Herdr agents-panel header rendered "spaces".

WezTerm native config load:
  Command: wezterm --config-file <worktree>/home/.config/wezterm/wezterm.lua show-keys
  Exit status: 0
  Result: WezTerm accepted and evaluated the complete changed configuration.

Configured values:
19:mouse_capture = false
21:# Set explicitly because with mouse_capture=false the header click-toggle is
23:agent_panel_sort = "spaces"
18:config.alternate_buffer_wheel_scroll_speed = 0
20:return config

Commit footprint:
 home/.config/herdr/config.toml   | 4 ++++
 home/.config/wezterm/wezterm.lua | 7 +++++++
 2 files changed, 11 insertions(+)

Changed paths:
home/.config/herdr/config.toml
home/.config/wezterm/wezterm.lua

Net line counts:
4	0	home/.config/herdr/config.toml
7	0	home/.config/wezterm/wezterm.lua
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat`, `git diff --name-only`, `git diff --numstat`, and the full scoped diff from `207ffe8d7f45baa4e8c20c16f77244d8eeb74b08` to `7bffee9ec00e7b6f1246ecd07d35420a67d38753`</code>
- <code>`HOME=.test-home HERDR_CONFIG_PATH=&#34;$PWD/home/.config/herdr/config.toml&#34; herdr --no-session` in an interactive PTY, confirming the real agents-panel header rendered `spaces`</code>
- <code>`wezterm --config-file &#34;$PWD/home/.config/wezterm/wezterm.lua&#34; show-keys`, confirming WezTerm accepted and evaluated the complete configuration</code>
- <code>`git status --short` and transient `.test-home` check after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
