### PR TITLE
fix: restore default terminal mouse behavior

### DIFF
--- a/home/.config/herdr/config.toml
+++ b/home/.config/herdr/config.toml
@@ -13,11 +13,5 @@ goto             = "prefix+g"
 copy_mode  = "prefix+y"  # herdr's copy-mode entry key; copy-mode's own internal keys (v/space select, y/Enter copy, q/Esc cancel) aren't configurable
 
 [ui]
-# Disable Herdr's host mouse capture so a trackpad event can't tailgate a held
-# Escape and get it swallowed in the pane (e.g. Neovim stuck in insert mode).
-# Only effective together with the pane keeping mouse off (see nvim mouse below).
-mouse_capture = false
-# Agents panel order: "spaces" (grouped by space, the default) vs "priority".
-# Set explicitly because with mouse_capture=false the header click-toggle is
-# unreachable, so the sort is fixed by this value.
+# Agents panel order: explicit choice of "spaces" (grouped by space, the default) over "priority".
 agent_panel_sort = "spaces"

--- a/home/.config/wezterm/wezterm.lua
+++ b/home/.config/wezterm/wezterm.lua
@@ -10,11 +10,4 @@ config.macos_window_background_blur = 50
 config.hide_tab_bar_if_only_one_tab = true
 config.window_decorations = "RESIZE"
 
--- With Herdr mouse_capture=false, the Herdr client is a full-screen alt-screen app
--- enabling no mouse reporting, so WezTerm would otherwise synthesize Up/Down arrow
--- keys for wheel scroll (default speed 3) and a pane REPL reads them as history
--- navigation. Set to 0 so wheel input in alternate-screen apps is never turned into
--- arrow keys. Scroll pane scrollback with PageUp/PageDown or copy-mode (prefix+y).
-config.alternate_buffer_wheel_scroll_speed = 0
-
 return config


### PR DESCRIPTION
## Intent

Revert two config lines in this PUBLIC dotfiles repo to restore parity with the private repo after the captain corrected the live behavior. This is a pure CONFIG revert - NOT a code fix and deliberately NOT a Herdr source patch or vendored fork.

Two files changed:
1. home/.config/herdr/config.toml: removed the [ui] mouse_capture=false line and its explanatory comment, returning Herdr to its DEFAULT host mouse capture. Kept agent_panel_sort="spaces" (this stays intentionally), but rewrote its comment because the old comment justified the setting via mouse_capture=false (header click-toggle unreachable) which is no longer true; the new comment frames "spaces" as an explicit ordering choice over "priority". No [keys] changes.
2. home/.config/wezterm/wezterm.lua: removed config.alternate_buffer_wheel_scroll_speed=0 and its preceding comment block. return config left intact, no double blank line.

Deliberate scope decisions (should NOT be flagged as mistakes/omissions): The Neovim mouse setting (home/.config/nvim/lua/vim_config.lua o.mouse='') is intentionally left EXACTLY as-is and untouched. No keybindings touched. No local patched Herdr fork was added/built/vendored - that upstream Herdr fix remains a FUTURE follow-up only, by design. Nothing restarted or rebuilt. The Escape-swallow durable fix is explicitly NOT solved by this change and remains an upstream Herdr follow-up.

Validation already done locally: Herdr TOML parses (single [ui] table, mouse_capture gone, agent_panel_sort still "spaces"); WezTerm Lua parses cleanly via wezterm and alternate_buffer_wheel_scroll_speed no longer appears.

## What Changed

- Restore Herdr’s default host mouse capture while retaining the explicit `spaces` agent panel ordering.
- Remove WezTerm’s alternate-buffer wheel-scroll override so its default scrolling behavior applies again.

## Risk Assessment

✅ Low: The narrowly scoped configuration revert exactly matches the authoritative intent, preserves the required settings and untouched files, and introduces no material correctness or compatibility risks.

## Testing

Inspected the target diff, loaded the explicit WezTerm config with the installed binary, parsed Herdr TOML, verified Herdr’s shipped defaults and exact untouched scope, and captured focused evidence; all executable checks passed, while a live Herdr launch was intentionally not disturbed.

<details>
<summary>Evidence: Config revert evidence</summary>

<code>Herdr’s shipped default has mouse capture enabled; the worktree config omits that override while retaining `agent_panel_sort = &#34;spaces&#34;`. WezTerm loaded the worktree configuration successfully. Exact-scope assertions also passed.</code>

```text
Herdr shipped default relevant UI settings:
[ui]
# mouse_capture = true
# agent_panel_sort = "spaces"

Worktree Herdr relevant UI settings:
[ui]
agent_panel_sort = "spaces"

WezTerm explicit worktree config load:
wezterm --config-file <worktree>/home/.config/wezterm/wezterm.lua show-keys
loaded successfully; generated 274 effective key assignment lines

Forbidden removed overrides across tracked files:
none found

Herdr TOML parsed by Nix:
{ keys = { close_tab = "prefix+ampersand"; copy_mode = "prefix+y"; focus_pane_down = "prefix+j"; focus_pane_left = "prefix+h"; focus_pane_right = "prefix+l"; focus_pane_up = "prefix+k"; goto = "prefix+g"; new_tab = "prefix+c"; prefix = "ctrl+b"; split_horizontal = "prefix+double_quote"; split_vertical = "prefix+percent"; workspace_picker = "prefix+w"; }; ui = { agent_panel_sort = "spaces"; }; }

Exact-scope assertions:
only the two intended config files changed
Herdr [keys] section is byte-for-byte unchanged between commits
Neovim vim_config.lua is byte-for-byte unchanged between commits
WezTerm ends with one blank line before return config
```
</details>
<details>
<summary>Evidence: Parsed Herdr configuration</summary>

<code>Nix-parsed Herdr configuration showing the complete unchanged keys table and UI containing only `agent_panel_sort = &#34;spaces&#34;`.</code>

```text
{ keys = { close_tab = "prefix+ampersand"; copy_mode = "prefix+y"; focus_pane_down = "prefix+j"; focus_pane_left = "prefix+h"; focus_pane_right = "prefix+l"; focus_pane_up = "prefix+k"; goto = "prefix+g"; new_tab = "prefix+c"; prefix = "ctrl+b"; split_horizontal = "prefix+double_quote"; split_vertical = "prefix+percent"; workspace_picker = "prefix+w"; }; ui = { agent_panel_sort = "spaces"; }; }
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --unified=80 b9ea27acd31a936ac11cc4f27e391f7096eb478b..7f14462b595475c420699585a31b4c0aae655877` for both changed files.</code>
- <code>Ran `wezterm --config-file &#34;$PWD/home/.config/wezterm/wezterm.lua&#34; show-keys` to load the worktree configuration through the installed application.</code>
- <code>Ran `herdr --default-config` and compared its relevant `[ui]` defaults with the worktree configuration.</code>
- <code>Parsed `home/.config/herdr/config.toml` using `builtins.fromTOML` through `nix eval`.</code>
- <code>Ran repository-wide `git grep` assertions for removed `mouse_capture = false` and `alternate_buffer_wheel_scroll_speed` overrides.</code>
- <code>Asserted only the two intended files changed, Herdr’s `[keys]` section was unchanged, Neovim’s `vim_config.lua` was unchanged, and WezTerm retained one blank line before `return config`.</code>
- <code>Attempted `HERDR_CONFIG_PATH=&#34;$PWD/home/.config/herdr/config.toml&#34; herdr --no-session`; the existing live Herdr instance correctly prevented a second launch, so it was not restarted or reloaded.</code>
- <code>Checked `git status --short` and confirmed testing left no worktree changes.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
