### PR TITLE
Prefer direct paths for operational work

### DIFF
--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -5,6 +5,7 @@
 - Never manually modify CHANGELOG.md files or any files that are marked as auto-generated
 - When making technical decisions, do not give much weight to development cost.
   Instead, prefer quality, simplicity, robustness, scalability, and long term maintainability.
+- For one-off or infrequent operational work, start with the simplest direct end-to-end path. Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.
 - When doing bug fixes, always start with reproducing the bug in an E2E setting as closely aligned with how an end user would experience it as possible.
   This makes sure you find the real problem so your fix will actually solve it.
 - When end-to-end testing a product, be picky about the UI you see and be obsessed with pixel perfection.


### PR DESCRIPTION
## Summary

- document a preference for the simplest direct end-to-end path for one-off operational work

## Validation

- inspected the exact diff
- ran `git diff --check`
- verified Markdown bullet formatting and trailing whitespace