### PR TITLE
feat(pi): declare pi-web-access package pin

### DIFF
--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -12,6 +12,7 @@
   "followUpMode": "all",
   "collapseChangelog": true,
   "packages": [
+    "npm:pi-web-access@0.14.0",
     "npm:@ryan_nookpi/pi-extension-codex-fast-mode@0.2.6",
     "git:github.com/algal/pi-openai-server-compaction@c6d593087709e9481223dc6c6c2269b371b5e055"
   ]


### PR DESCRIPTION
Adds `npm:pi-web-access@0.14.0` to the Pi `packages` array in `home/.pi/agent/settings.json`.

This is the only tracked change: one added line, exact immutable version pin, consistent with the repo's stated pinning policy for third-party Pi sources.

No other file, line, config, credential, README, or test is touched.