### PR TITLE
Port dotfiles preferences, add varlock, and update packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Running the switch builds:
 - System settings (dark mode, key repeat, dock, Finder, trackpad)
 - Homebrew apps (casks and CLI tools)
 - Nix user packages (ripgrep, fd, fzf, jq, lazygit, Neovim, Hack Nerd Font)
-- Shell (zsh, aliases, starship prompt)
+- Shell (zsh, aliases, history and completion behavior, starship prompt)
+- Git (identity, ~28 aliases, git-lfs) via `programs.git`
 - Editor (Neovim config with the rose-pine moon theme)
 - Terminal (WezTerm config with the rose-pine moon theme and dimmed unfocused windows)
 - Agent configs (Claude, Codex, opencode all share one AGENTS.md)
@@ -93,25 +94,20 @@ No separate build-and-copy step.
 This repo is mine.
 If you clone it, review these before you run `bootstrap.sh`:
 
-- **Username**: run `./bootstrap.sh` (it detects your macOS username and offers to set it) OR change the single `user = "kunchen"` line in `flake.nix`.
+- **Username**: run `./bootstrap.sh` (it detects your macOS username and offers to set it) OR change the single `user = "mikes"` line in `flake.nix`.
   Everything else (`configuration.nix`, `home.nix`, home directory paths) is threaded from that one variable.
 - **Host label** `"mac"`, in three places: `flake.nix` (the `darwinConfigurations."mac"` name), `rebuild.sh:5` (the `#mac` at the end of the flake reference), and `bootstrap.sh`'s first-switch command (also `#mac`).
   All three have to match.
 - **CPU architecture**, `hostPlatform` in `configuration.nix` (see Prerequisites above).
 
-**Git identity:** this config deliberately does not set your git name or email.
-Git will stop your first commit and tell you to set them (`git config --global user.name "Your Name"` and `git config --global user.email you@example.com`).
-If you'd rather manage that declaratively, add this back to `home.nix` with your own identity:
+**Git identity:** unlike upstream, this fork *does* manage git declaratively - `programs.git` in
+`home.nix` sets the identity, the aliases, and the behavior flags, and installs git and git-lfs from
+nixpkgs. If you clone this repo, change `settings.user` in `home.nix` to your own name and email
+before the first switch, or you will commit as me.
 
-```nix
-programs.git = {
-  enable = true;
-  settings.user = {
-    name = "Your Name";
-    email = "you@example.com";
-  };
-};
-```
+Home Manager writes `~/.config/git/config`. Git reads `~/.gitconfig` *after* that file, so a
+pre-existing `~/.gitconfig` silently overrides everything here - move it aside before the first
+switch.
 
 **Homebrew cleanup warning:** `configuration.nix` sets `homebrew.onActivation.cleanup = "zap"`.
 That means every time you switch, Homebrew removes any package or cask on your machine that isn't listed in the `brews` and `casks` arrays in `configuration.nix`.

--- a/configuration.nix
+++ b/configuration.nix
@@ -70,6 +70,7 @@
       "codex"                       # the `co` alias
       "gcloud-cli"                  # gcloud completion sourced from home.nix initContent
       "android-ndk"                 # ANDROID_NDK_HOME
+      "opensuperwhisper"            # whisper dictation; prompts for mic + accessibility on first run
       "kunchenguid/tap/pi-launcher" # GUI launcher for the Pi coding agent
       "automic-vault/isotopes/automic-vault" # security layer for dev environments; arm64 + Sonoma or newer
     ];

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,4 +1,4 @@
-{ user, ... }:
+{ pkgs, user, ... }:
 
 {
   # Determinate already manages the Nix daemon, so nix-darwin shouldn't.
@@ -28,6 +28,24 @@
   nix-homebrew = {
     enable = true;
     inherit user;
+    # Take over the pre-existing Homebrew install instead of demanding it be
+    # uninstalled first. Deletes the Homebrew repositories, keeps the packages.
+    autoMigrate = true;
+
+    # nix-homebrew defaults to its own brew-src input, pinned to 6.0.1. Homebrew's
+    # JSON API serves cask definitions using the `command_wrapper` stanza, which only
+    # landed in brew 6.0.13, so casks like android-ndk fail with "undefined method".
+    # `package` is the brew source tree itself, and nix-homebrew reads `version` off
+    # it to rewrite HOMEBREW_VERSION, so both extra attrs have to be set.
+    package = (pkgs.fetchFromGitHub {
+      owner = "Homebrew";
+      repo = "brew";
+      tag = "6.0.18";
+      hash = "sha256-VBESSoJccikdhxh3vp3SQeG7cZXTOulMvVkoSqNDEhs=";
+    }) // {
+      name = "brew-6.0.18";
+      version = "6.0.18";
+    };
   };
   homebrew = {
     enable = true;
@@ -36,10 +54,15 @@
     onActivation.extraFlags = [ "--force" ];
     brews = [
       "herdr"
+      "gnupg"        # gpg - GPG_TTY export in home.nix initContent
+      "pyenv"        # pyenv init in home.nix initContent
     ];
     casks = [
       "wezterm"
       "claude-code"
+      "codex"        # the `co` alias
+      "gcloud-cli"   # gcloud completion sourced from home.nix initContent
+      "android-ndk"  # ANDROID_NDK_HOME
     ];
   };
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -52,17 +52,26 @@
     onActivation.cleanup = "zap";  # remove anything not listed here
     onActivation.autoUpdate = true;
     onActivation.extraFlags = [ "--force" ];
+    taps = [
+      "kunchenguid/tap"        # third-party tap for the pi-launcher cask below
+      "automic-vault/isotopes" # third-party tap for the automic-vault cask below
+      "dmno-dev/tap"           # varlock - AI-safe .env workflow
+    ];
     brews = [
       "herdr"
       "gnupg"        # gpg - GPG_TTY export in home.nix initContent
       "pyenv"        # pyenv init in home.nix initContent
+      "libb2"        # blake2 for pyenv-built pythons - CPython's _blake2 module dlopens this
+      "varlock"      # AI-safe .env / secrets workflow
     ];
     casks = [
       "wezterm"
       "claude-code"
-      "codex"        # the `co` alias
-      "gcloud-cli"   # gcloud completion sourced from home.nix initContent
-      "android-ndk"  # ANDROID_NDK_HOME
+      "codex"                       # the `co` alias
+      "gcloud-cli"                  # gcloud completion sourced from home.nix initContent
+      "android-ndk"                 # ANDROID_NDK_HOME
+      "kunchenguid/tap/pi-launcher" # GUI launcher for the Pi coding agent
+      "automic-vault/isotopes/automic-vault" # security layer for dev environments; arm64 + Sonoma or newer
     ];
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -98,7 +98,28 @@
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "treehouse": "treehouse"
+      }
+    },
+    "treehouse": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787457221,
+        "narHash": "sha256-1LhgLmeI6sdV8Cka9wI9bp02pOyenujHhFewweqkG4M=",
+        "owner": "kunchenguid",
+        "repo": "treehouse",
+        "rev": "5aafb9eeebc8ba34677140d822498a818ea36e9e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kunchenguid",
+        "repo": "treehouse",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,12 @@
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+
+    treehouse.url = "github:kunchenguid/treehouse";
+    treehouse.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ self, nix-darwin, nix-homebrew, home-manager, nixpkgs }:
+  outputs = inputs@{ self, nix-darwin, nix-homebrew, home-manager, nixpkgs, treehouse }:
     let
       # The one username line to change if this isn't your machine.
       # bootstrap.sh offers to rewrite this for you if your macOS username differs.

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     let
       # The one username line to change if this isn't your machine.
       # bootstrap.sh offers to rewrite this for you if your macOS username differs.
-      user = "kunchen";
+      user = "mikes";
     in
     {
       darwinConfigurations."mac" = nix-darwin.lib.darwinSystem {

--- a/home.nix
+++ b/home.nix
@@ -16,6 +16,8 @@ in
     jq        # json on the command line
     lazygit
     neovim
+    gh        # github cli
+    nodejs    # node, plus the bundled npm and npx
     # the font everything renders in
     nerd-fonts.hack
   ];
@@ -29,6 +31,7 @@ in
     MANPAGER = "less -X";                 # don't clear the screen after quitting a man page
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = "YES";
     ANDROID_NDK_HOME = "/opt/homebrew/share/android-ndk";
+    NPM_CONFIG_PREFIX = "$HOME/.npm-global";  # nix's npm is read-only; keep global installs out of the store
   };
 
   # Toolchains that install themselves under $HOME rather than through nix.
@@ -37,6 +40,7 @@ in
     "$HOME/.local/bin"
     "$HOME/.cargo/bin"
     "$HOME/.bun/bin"
+    "$HOME/.npm-global/bin"
   ];
 
   programs.zsh = {

--- a/home.nix
+++ b/home.nix
@@ -20,23 +20,182 @@ in
     nerd-fonts.hack
   ];
   fonts.fontconfig.enable = true;
-  home.sessionVariables.EDITOR = "nvim";
+
+  home.sessionVariables = {
+    EDITOR = "nvim";
+    LANG = "en_US.UTF-8";
+    LC_ALL = "en_US.UTF-8";
+    LSCOLORS = "BxBxhxDxfxhxhxhxhxcxcx";  # palette for the `ls -G` aliases below
+    MANPAGER = "less -X";                 # don't clear the screen after quitting a man page
+    OBJC_DISABLE_INITIALIZE_FORK_SAFETY = "YES";
+    ANDROID_NDK_HOME = "/opt/homebrew/share/android-ndk";
+  };
+
+  # Toolchains that install themselves under $HOME rather than through nix.
+  home.sessionPath = [
+    "$HOME/bin"
+    "$HOME/.local/bin"
+    "$HOME/.cargo/bin"
+    "$HOME/.bun/bin"
+  ];
 
   programs.zsh = {
     enable = true;
     autosuggestion.enable = true;      # ghost text from history
     syntaxHighlighting.enable = true;  # commands turn green when valid
+
+    history = {
+      size = 32768;
+      save = 32768;
+      ignoreAllDups = true;  # HISTCONTROL=ignoredups
+      ignoreSpace = true;    # HISTCONTROL=ignorespace
+      share = true;
+    };
+
     initContent = ''
       bindkey '^f' autosuggest-accept
+
+      # Up/Down search history using what is already typed, rather than walking
+      # every past command. Carried over from the old ~/.inputrc.
+      autoload -U up-line-or-beginning-search down-line-or-beginning-search
+      zle -N up-line-or-beginning-search
+      zle -N down-line-or-beginning-search
+      bindkey '^[[A' up-line-or-beginning-search
+      bindkey '^[[B' down-line-or-beginning-search
+      bindkey '^[[3;3~' kill-word          # Alt+Delete kills the preceding word
+
+      zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'  # completion-ignore-case
+      zstyle ':completion:*' list-dirs-first true
+      compdef g=git                                              # complete `g` as git
+
+      setopt AUTO_CD NO_CASE_GLOB
+
+      # Non-nix toolchains. Each guard is a no-op when the tool isn't installed.
+      export GPG_TTY=$(tty)
+      command -v pyenv >/dev/null && eval "$(pyenv init -)"
+      [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
+      [[ -r /opt/homebrew/share/google-cloud-sdk/path.zsh.inc ]] \
+        && source /opt/homebrew/share/google-cloud-sdk/path.zsh.inc
+      [[ -r /opt/homebrew/share/google-cloud-sdk/completion.zsh.inc ]] \
+        && source /opt/homebrew/share/google-cloud-sdk/completion.zsh.inc
     '';
+
     shellAliases = {
+      # navigation
       ".." = "cd ..";
+      "..." = "cd ../..";
+      "...." = "cd ../../..";
+      p = "cd ~/Projects";
+      dl = "cd ~/Downloads";
+      dt = "cd ~/Desktop";
+
+      # git
+      g = "git";
       add = "git add .";
       push = "git push";
       pull = "git pull";
       m = "git switch main";
+
+      # ls - BSD ls on macOS; LSCOLORS above supplies the palette
+      ls = "command ls -G";
+      l = "ls -lF";
+      la = "ls -lAF";
+      lsd = "ls -lF | grep --color=never '^d'";
+
+      # misc
+      activate = ". venv/bin/activate";
+      reload = "exec $SHELL -l";
+      path = "print -l \${(s.:.)PATH}";
+
+      # agents
       cc = "claude --dangerously-skip-permissions";
       co = "codex --full-auto";
+    };
+  };
+
+  programs.git = {
+    enable = true;
+    lfs.enable = true;
+    settings = {
+      user = {
+        name = "Michael Shandrovskiy";
+        email = "misha84@gmail.com";
+      };
+      commit.gpgsign = false;
+      pull.rebase = false;
+      core = {
+        untrackedCache = true;
+        whitespace = "space-before-tab,-indent-with-non-tab,trailing-space";
+      };
+      diff.renames = "copies";
+      merge.log = true;
+      help.autocorrect = 1;
+      push = {
+        default = "simple";
+        followTags = true;
+      };
+      color.ui = "auto";
+
+      alias = {
+        # Abbreviated SHA, description, and history graph of the latest 20 commits
+        l = "log --pretty=oneline -n 20 --graph --abbrev-commit";
+
+        s = "status -s";
+        st = "status";
+
+        # Diff between the latest commit and the current state
+        d = ''!git diff-index --quiet HEAD -- || clear; git --no-pager diff --patch-with-stat'';
+
+        # Diff between the state $1 revisions ago and the current state
+        di = ''!d() { git diff --patch-with-stat HEAD~$1; }; git diff-index --quiet HEAD -- || clear; d'';
+
+        # Diff of what is staged
+        diffs = "diff --staged";
+
+        p = "pull --recurse-submodules";
+        c = "clone --recursive";
+        ca = "!git add -A && git commit -av";
+        co = "checkout";
+        br = "branch";
+
+        # Switch to a branch, creating it if necessary
+        go = ''!f() { git checkout -b "$1" 2> /dev/null || git checkout "$1"; }; f'';
+
+        tags = "tag -l";
+        branches = "branch -a";
+        remotes = "remote -v";
+        aliases = "config --get-regexp alias";
+
+        amend = "commit --amend --reuse-message=HEAD";
+
+        # Credit an author on the latest commit
+        credit = ''!f() { git commit --amend --author "$1 <$2>" -C HEAD; }; f'';
+
+        # Interactive rebase with the given number of latest commits
+        reb = ''!r() { git rebase -i HEAD~$1; }; r'';
+
+        # Remove the old tag with this name and tag the latest commit with it
+        retag = ''!r() { git tag -d $1 && git push origin :refs/tags/$1 && git tag $1; }; r'';
+
+        # Find branches / tags containing a commit
+        fb = ''!f() { git branch -a --contains $1; }; f'';
+        ft = ''!f() { git describe --always --contains $1; }; f'';
+
+        # Find commits by source code / by commit message
+        fc = ''!f() { git log --pretty=format:'%C(yellow)%h  %Cblue%ad  %Creset%s%Cgreen  [%cn] %Cred%d' --decorate --date=short -S$1; }; f'';
+        fm = ''!f() { git log --pretty=format:'%C(yellow)%h  %Cblue%ad  %Creset%s%Cgreen  [%cn] %Cred%d' --decorate --date=short --grep=$1; }; f'';
+
+        # Delete branches already merged into the current one
+        dm = ''!git branch --merged | grep -v '\*' | xargs -n 1 git branch -d'';
+
+        contributors = "shortlog --summary --numbered";
+
+        # Email configured for the current repository
+        whoami = "config user.email";
+
+        # Merge a GitHub pull request on top of the current branch, or of $2
+        mpr = ''!f() { declare currentBranch="$(git symbolic-ref --short HEAD)"; declare branch="''${2:-$currentBranch}"; if [ $(printf "%s" "$1" | grep '^[0-9]\+$' > /dev/null; printf $?) -eq 0 ]; then git fetch origin refs/pull/$1/head:pr/$1 && git checkout -B $branch && git rebase $branch pr/$1 && git checkout -B $branch && git merge pr/$1 && git branch -D pr/$1 && git commit --amend -m "$(git log -1 --pretty=%B)\n\nCloses #$1."; fi }; f'';
+      };
     };
   };
 

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -1,7 +1,8 @@
 {
-  "theme": "dark-ansi",
   "statusLine": {
     "type": "command",
     "command": "input=$(cat); model=$(echo \"$input\" | jq -r '.model.display_name'); used=$(echo \"$input\" | jq -r '.context_window.used_percentage // empty'); if [ -n \"$used\" ]; then printf \"%s | ctx: %.0f%% used\" \"$model\" \"$used\"; else printf \"%s\" \"$model\"; fi"
-  }
+  },
+  "theme": "dark-ansi",
+  "skipDangerousModePermissionPrompt": true
 }

--- a/home/.config/nvim/lazy-lock.json
+++ b/home/.config/nvim/lazy-lock.json
@@ -1,11 +1,11 @@
 {
   "diffview.nvim": { "branch": "main", "commit": "4516612fe98ff56ae0415a259ff6361a89419b0a" },
-  "gitsigns.nvim": { "branch": "main", "commit": "eb60cc7b94c46005237fd34170d76f3a089a90aa" },
-  "lazy.nvim": { "branch": "main", "commit": "85c7ff3711b730b4030d03144f6db6375044ae82" },
-  "neogit": { "branch": "master", "commit": "43ea1a0854052e583f647e0b35879f0158a70a78" },
+  "gitsigns.nvim": { "branch": "main", "commit": "5be654f2232c10ddcad19c1607a67b6b4b78fc29" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "neogit": { "branch": "master", "commit": "5adc81b26232954cd7a90f158aa7844c18fc3165" },
   "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
-  "rose-pine": { "branch": "main", "commit": "cf2a288696b03d0934da713d66c6d71557b5c997" },
+  "rose-pine": { "branch": "main", "commit": "ff483051a47e27d84bdef47703538df1ed9f4a47" },
   "snacks.nvim": { "branch": "main", "commit": "882c996cf28183f4d63640de0b4c02ec886d01f2" },
   "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }

--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -15,5 +15,9 @@
     "npm:pi-web-access@0.14.0",
     "npm:@ryan_nookpi/pi-extension-codex-fast-mode@0.2.6",
     "git:github.com/algal/pi-openai-server-compaction@c6d593087709e9481223dc6c6c2269b371b5e055"
-  ]
+  ],
+  "lastChangelogVersion": "0.84.2",
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-opus-4-8",
+  "defaultThinkingLevel": "medium"
 }

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -2,4 +2,12 @@
 set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 ln -sfn "$DIR" ~/.dotfiles
-exec sudo darwin-rebuild switch --flake ~/.dotfiles#mac
+# sudo resolves the command against its own secure PATH, which does not include
+# /run/current-system/sw/bin, so a bare `sudo darwin-rebuild` fails with
+# "command not found" even though darwin-rebuild is installed. Same workaround
+# bootstrap.sh uses for `nix`: resolve the absolute path first, then invoke it.
+DARWIN_REBUILD="$(command -v darwin-rebuild || true)"
+: "${DARWIN_REBUILD:=/run/current-system/sw/bin/darwin-rebuild}"
+# "mac" is the flake host label - if you renamed it, change it in flake.nix
+# and bootstrap.sh too.
+exec sudo "$DARWIN_REBUILD" switch --flake ~/.dotfiles#mac


### PR DESCRIPTION
## Summary

- **Nix / Homebrew**: add `dmno-dev/tap` + `varlock` brew, `opensuperwhisper` cask, `treehouse` flake input; add `gh` and `nodejs` nix packages; set `NPM_CONFIG_PREFIX` so global npm installs stay out of the nix store; add `~/.npm-global/bin` to PATH
- **Varlock**: initialize `.env.schema` with all project env vars; install Varlock skill; add commented-out plugin blocks for 1Password, AWS, GCP Secret Manager, and macOS Keychain (auto-downloaded on first use, no separate npm install needed)
- **Claude settings**: add `skipDangerousModePermissionPrompt`
- **Neovim**: bump gitsigns, lazy.nvim, neogit, rose-pine lock commits
- **Pi agent**: set `defaultProvider=anthropic`, `defaultModel=claude-opus-4-8`, `defaultThinkingLevel=medium`

## Test plan

- [ ] `darwin-rebuild switch --flake .` applies cleanly
- [ ] `varlock load --agent` returns `{}` (all vars optional, none missing)
- [ ] `which gh`, `which node`, `which varlock` resolve after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)