### PR TITLE
Remove experimental Pi OpenAI server compaction package

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,12 @@ Calm never changes prompts, tool execution, model context, session data, or orde
 
 Pi's package system declares two third-party sources in the linked global `settings.json`:
 
+- `npm:pi-web-access@0.14.0` - the exact public npm release for web access.
 - `npm:@ryan_nookpi/pi-extension-codex-fast-mode@0.2.6` - the exact public npm release from `ryan_nookpi`.
-- `git:github.com/algal/pi-openai-server-compaction@c6d593087709e9481223dc6c6c2269b371b5e055` - the exact public `algal` commit for experimental OpenAI server-side compaction.
 
-The version and commit are immutable pins, so Pi does not move them during package updates. Deliberate updates require a new source and security audit, followed by an explicit pin change in `home/.pi/agent/settings.json`. On Pi 0.82.0, global settings declarations install missing pinned packages automatically at startup. No one-time install command is required. Pi keeps the downloaded npm and git package trees in its own unmanaged `~/.pi/agent/npm` and `~/.pi/agent/git` runtime directories, outside Home Manager and Git tracking.
+The versions are immutable pins, so Pi does not move them during package updates. Deliberate updates require a new source and security audit, followed by an explicit pin change in `home/.pi/agent/settings.json`. On Pi 0.82.0, global settings declarations install missing pinned packages automatically at startup. No one-time install command is required. Pi keeps the downloaded npm package trees in its own unmanaged `~/.pi/agent/npm` runtime directory, outside Home Manager and Git tracking.
 
-Both packages execute with your full user permissions and must be trusted like any other executable code. The compaction package is experimental, sends the relevant OpenAI compaction and continuity data to OpenAI, and upstream declares the stale peer range `>=0.80.9 <0.81.0`; this exact immutable ref was locally proven to load and perform remote compaction on Pi 0.82.0. Do not treat that proof as a guarantee for a different Pi version or a different package ref.
+Both packages execute with your full user permissions and must be trusted like any other executable code.
 
 Home Manager deliberately does not manage `~/.pi/agent` itself, or Pi authentication, sessions, trust decisions, caches, npm/git package trees, or any other runtime state. The model overrides contain no credentials or endpoint settings, do not choose a default model, and only take effect after you authenticate Pi yourself. This remains an additive post-video layer: it does not install Pi, a launcher, or package source code into this repository.
 

--- a/home/.pi/agent/settings.json
+++ b/home/.pi/agent/settings.json
@@ -13,7 +13,6 @@
   "collapseChangelog": true,
   "packages": [
     "npm:pi-web-access@0.14.0",
-    "npm:@ryan_nookpi/pi-extension-codex-fast-mode@0.2.6",
-    "git:github.com/algal/pi-openai-server-compaction@c6d593087709e9481223dc6c6c2269b371b5e055"
+    "npm:@ryan_nookpi/pi-extension-codex-fast-mode@0.2.6"
   ]
 }


### PR DESCRIPTION
## Summary
- Drop `git:github.com/algal/pi-openai-server-compaction@c6d593087709e9481223dc6c6c2269b371b5e055` from managed Pi `settings.json`.
- Document the remaining pinned npm packages (`pi-web-access` and `pi-extension-codex-fast-mode`) and the pin/update policy without treating the removed package as installed.
- Leave unrelated Pi settings, local extensions, and Home Manager wiring unchanged.

## Test plan
- [x] `home/.pi/agent/settings.json` remains valid JSON and no longer lists `algal/pi-openai-server-compaction`.
- [x] README package inventory matches the remaining pins.
- [x] Grep shows no other owned public references to the removed package.
- [ ] Do not merge this PR from the worker; firstmate owns autonomous merge.